### PR TITLE
added support for double click reset to a known value

### DIFF
--- a/examples/example_knob.rs
+++ b/examples/example_knob.rs
@@ -87,7 +87,8 @@ impl eframe::App for KnobDemo {
                                 .with_background_arc(self.show_bg_arc)
                                 .with_show_filled_segments(self.show_filled)
                                 .with_colors(self.knob_color, self.line_color, self.text_color)
-                                .with_step(self.use_step.then_some(0.02));
+                                .with_step(self.use_step.then_some(0.02))
+                                .with_double_click_reset(0.5);
 
                             if *label == "Wiper, Sweep" {
                                 knob = knob.with_sweep_range(0.25, 0.75).with_size(50.0);

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ pub struct KnobConfig {
     pub(crate) show_filled_segments: bool,
     pub(crate) min_angle: f32,
     pub(crate) max_angle: f32,
+    pub(crate) reset_value: Option<f32>,
 }
 
 impl KnobConfig {
@@ -36,6 +37,7 @@ impl KnobConfig {
             drag_sensitivity: 0.005,
             show_background_arc: true,
             show_filled_segments: true,
+            reset_value: None,
         }
     }
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -53,7 +53,7 @@ impl<'a> Knob<'a> {
             return self;
         }
 
-        self.config.min_angle =
+        self.config.min_angle = 
             start_angle_normalized.rem_euclid(1.0) * std::f32::consts::TAU + std::f32::consts::PI / 2.0;
         self.config.max_angle = self.config.min_angle + range.max(0.0) * std::f32::consts::TAU;
         self
@@ -156,6 +156,13 @@ impl<'a> Knob<'a> {
         self
     }
 
+    /// Sets a reset value to return to on doubleclick event.
+    ///
+    /// Default is 0.005.
+    pub fn with_double_click_reset(mut self, reset_value: f32) -> Self {
+        self.config.reset_value = Some(reset_value);
+        self
+    }
 }
 
 impl Widget for Knob<'_> {
@@ -168,7 +175,7 @@ impl Widget for Knob<'_> {
         let renderer = KnobRenderer::new(&self.config, current_value, self.min, self.max);
         let adjusted_size = renderer.calculate_size(ui);
 
-        let (rect, response) = ui.allocate_exact_size(adjusted_size, Sense::drag());
+        let (rect, response) = ui.allocate_exact_size(adjusted_size, Sense::click_and_drag());
 
         let mut response = response;
         if response.dragged() {
@@ -189,6 +196,10 @@ impl Widget for Knob<'_> {
             }
 
             response.mark_changed();
+        } else if response.double_clicked() {
+            if let Some(reset_value) = self.config.reset_value {
+                *self.value = reset_value
+            }
         }
 
         let knob_rect = renderer.calculate_knob_rect(rect);

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -157,8 +157,6 @@ impl<'a> Knob<'a> {
     }
 
     /// Sets a reset value to return to on doubleclick event.
-    ///
-    /// Default is 0.005.
     pub fn with_double_click_reset(mut self, reset_value: f32) -> Self {
         self.config.reset_value = Some(reset_value);
         self


### PR DESCRIPTION
Hi! great crate, really useful for an audio plugin I'm working on

This PR adds ability to define a double click action, such that the knob will reset to a known value provided by user

example for a Left-Right Pan knob, where double clicking will reset the value back to the center