### PR TITLE
Add fill_color

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -42,7 +42,7 @@ impl<'a> KnobRenderer<'a> {
         painter.circle_filled(
             center,
             radius - self.config.stroke_width / 2.0,
-            self.config.colors.knob_color.gamma_multiply(0.15),
+            self.config.colors.fill_color,
         );
 
         painter.circle_stroke(

--- a/src/style.rs
+++ b/src/style.rs
@@ -27,6 +27,8 @@ pub enum LabelPosition {
 pub struct KnobColors {
     /// Color of the knob's outline
     pub knob_color: Color32,
+    /// Color of the knob's fill
+    pub fill_color: Color32,
     /// Color of the indicator (wiper or dot)
     pub line_color: Color32,
     /// Color of the label text
@@ -37,6 +39,7 @@ impl Default for KnobColors {
     fn default() -> Self {
         Self {
             knob_color: Color32::GRAY,
+            fill_color: Color32::GRAY.gamma_multiply(0.15),
             line_color: Color32::GRAY,
             text_color: Color32::WHITE,
         }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -83,6 +83,9 @@ impl<'a> Knob<'a> {
     /// * `knob_color` - Color of the knob's outline
     /// * `line_color` - Color of the indicator
     /// * `text_color` - Color of the label text
+    ///
+    /// Note that this method sets the fill color to `knob_color` with 15% gamma.
+    /// Use [`Self::with_fill_color`] (after calling this method) to set the fill color.
     pub fn with_colors(
         mut self,
         knob_color: Color32,
@@ -90,8 +93,18 @@ impl<'a> Knob<'a> {
         text_color: Color32,
     ) -> Self {
         self.config.colors.knob_color = knob_color;
+        self.config.colors.fill_color = knob_color.gamma_multiply(0.15);
         self.config.colors.line_color = line_color;
         self.config.colors.text_color = text_color;
+        self
+    }
+
+    /// Sets the fill color of the knob
+    ///
+    /// # Arguments
+    /// * `fill_color` - Color of the knob's fill
+    pub fn with_fill_color(mut self, fill_color: Color32) -> Self {
+        self.config.colors.fill_color = fill_color;
         self
     }
 


### PR DESCRIPTION
This pull request addresses the `TODO: make an option` in `src/render.rs`.

This change is (as far as I can tell) backwards compatible:
* `egui_knob::style::KnobColors` gained a field, but this is not exposed.
* `egui_knob::Knob::with_colors()` and `egui_knob::style::KnobColors::default()` set `fill_color` to the same value as was used previously. No UI changes should occur.

The API is slightly awkward, in that `with_colors` has to be called before `with_fill_color`, but other solutions would require a breaking change for the API.