### PR TITLE
add helper function to create unnormalized step size when min/max != 0.0..=1.0

### DIFF
--- a/src/widget.rs
+++ b/src/widget.rs
@@ -160,6 +160,19 @@ impl<'a> Knob<'a> {
         self
     }
 
+    /// Calculates a normalized step size which corresponds to a true step in the min/max values
+    pub fn with_step_unormalized(mut self, step: f32) -> Self {
+        let step = step/(self.max-self.min);
+
+        if step >= 1.0 || step <= 0.0{
+            panic!("step value requested is out of valid range")
+        }
+
+        self.config.step = Some(step);
+        self        
+
+    }
+
     /// Controls whether to show the background arc indicating the full range
     pub fn with_background_arc(mut self, enabled: bool) -> Self {
         self.config.show_background_arc = enabled;

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -161,7 +161,7 @@ impl<'a> Knob<'a> {
     }
 
     /// Calculates a normalized step size which corresponds to a true step in the min/max values
-    pub fn with_step_unormalized(mut self, step: f32) -> Self {
+    pub fn with_step_unnormalized(mut self, step: f32) -> Self {
         let step = step/(self.max-self.min);
 
         if step >= 1.0 || step <= 0.0{


### PR DESCRIPTION
so I was working on updating a project that uses egui_knob (0.3.9) when I noticed some of my knobs broke
digging into the diffs between 0.3.9 and 0.5.0 the major change of adding logarithmic support meant that values always use the normalized range regardless of min/max values
as such, when I used `.with_step(10.0)`, it was clamped to a step of **1.0** and basically breaking.

this PR adds an alternative `.with_step` , `.with_step_unnormalized(f32)`  which allows the user to enter an unnormalized step and the widget will calculate the correct step size.

